### PR TITLE
fix: Generate correct collection size when annotation_types.Len is used

### DIFF
--- a/polyfactory/value_generators/constrained_collections.py
+++ b/polyfactory/value_generators/constrained_collections.py
@@ -42,7 +42,7 @@ def handle_constrained_collection(  # noqa: C901
         return collection_type()
 
     min_items = abs(min_items if min_items is not None else (max_items or 0))
-    max_items = abs(max_items if max_items is not None else min_items + 1)
+    max_items = abs(max_items) if max_items is not None else max(min_items, 1)
 
     if max_items < min_items:
         msg = "max_items must be larger or equal to min_items"
@@ -110,7 +110,7 @@ def handle_constrained_mapping(
         return {}
 
     min_items = abs(min_items if min_items is not None else (max_items or 0))
-    max_items = abs(max_items if max_items is not None else min_items + 1)
+    max_items = abs(max_items) if max_items is not None else max(min_items, 1)
 
     if max_items < min_items:
         msg = "max_items must be larger or equal to min_items"

--- a/tests/test_collection_length.py
+++ b/tests/test_collection_length.py
@@ -1,6 +1,7 @@
 from enum import Enum
 from typing import Any, Dict, FrozenSet, List, Literal, Optional, Set, Tuple, get_args
 
+import annotated_types as at
 import pytest
 
 from pydantic import BaseModel
@@ -9,7 +10,22 @@ from pydantic.dataclasses import dataclass
 from polyfactory.factories import DataclassFactory
 from polyfactory.factories.pydantic_factory import ModelFactory
 
+from typing import Annotated
+
 MIN_MAX_PARAMETERS = ((10, 15), (20, 25), (30, 40), (40, 50))
+
+
+def test_annotated_type_length() -> None:
+    @dataclass
+    class Foo:
+        foo: Annotated[List[int], at.Len(1)]
+    class FooFactory(DataclassFactory[Foo]):
+        __model__ = Foo
+        __randomize_collection_length__ = True
+
+    for _ in range(10):
+        foo = FooFactory.build()
+        assert len(foo.foo) == 1, len(foo.foo)
 
 
 @pytest.mark.parametrize("type_", (List, Set))


### PR DESCRIPTION
## Description
Fixes a bug where annotation_types.Len can go over the described length

## Test
### Before the fix:
```
➜  polyfactory git:(workback-fix-710) pytest tests/test_collection_length.py
======================================= test session starts =======================================
platform darwin -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/priyank/OSS/polyfactory
configfile: pyproject.toml
plugins: hypothesis-6.135.4, Faker-37.3.0, cov-6.1.1, asyncio-1.0.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 80 items

tests/test_collection_length.py F.......................................................... [ 73%]
.....................                                                                       [100%]

============================================ FAILURES =============================================
___________________________________ test_annotated_type_length ____________________________________

    def test_annotated_type_length() -> None:
        @dataclass
        class Foo:
            foo: Annotated[List[int], at.Len(1)]
        class FooFactory(DataclassFactory[Foo]):
            __model__ = Foo
            __randomize_collection_length__ = True

        for _ in range(10):
            foo = FooFactory.build()
>           assert len(foo.foo) == 1, len(foo.foo)
E           AssertionError: 2
E           assert 2 == 1
E            +  where 2 = len([5068, 9979])
E            +    where [5068, 9979] = test_annotated_type_length.<locals>.Foo(foo=[5068, 9979]).foo

tests/test_collection_length.py:28: AssertionError
===================================== short test summary info =====================================
FAILED tests/test_collection_length.py::test_annotated_type_length - AssertionError: 2
================================== 1 failed, 79 passed in 0.53s ===================================
```

### After the fix
```
➜  polyfactory git:(workback-fix-710) ✗ pytest tests/test_collection_length.py
=============================================== test session starts ================================================
platform darwin -- Python 3.12.10, pytest-8.4.0, pluggy-1.6.0
rootdir: /Users/priyank/OSS/polyfactory
configfile: pyproject.toml
plugins: hypothesis-6.135.4, Faker-37.3.0, cov-6.1.1, asyncio-1.0.0
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 80 items

tests/test_collection_length.py ............................................................................ [ 95%]
....                                                                                                         [100%]

================================================ 80 passed in 0.48s ================================================
```
## Closes
Fixes #710
